### PR TITLE
add return_k = TRUE for pareto smoothing

### DIFF
--- a/R/update_quantities.R
+++ b/R/update_quantities.R
@@ -43,7 +43,8 @@ update_quantities <- function(draws, orig_log_prob_prop,
   }
 
   pareto_smoothed_w_new <- posterior::pareto_smooth(exp(lw_new - matrixStats::logSumExp(lw_new)),
-    tail = "right", r_eff = 1
+                                                    tail = "right", r_eff = 1,
+                                                    return_k = TRUE
   )
   k <- pareto_smoothed_w_new$diagnostics$khat
   lw <- log(as.vector(pareto_smoothed_w_new$x))


### PR DESCRIPTION
This is required due to changes in the latest posterior github release. It shouldn't affect compatibility with other versions as it's just a change of the default in posterior (now default is return_k = FALSE).