### PR TITLE
check cmdstan path before running cmdstanr tests

### DIFF
--- a/tests/testthat/test-moment-match-cmdstan-analytical.R
+++ b/tests/testthat/test-moment-match-cmdstan-analytical.R
@@ -1,7 +1,8 @@
 cmdstanr_available <- require(cmdstanr)
+cmdstan_path_available <- !is.null(cmdstanr::cmdstan_version(error_on_NA=FALSE))
 
 # Run these tests only if cmdstanr is installed
-if (cmdstanr_available) {
+if (cmdstanr_available && cmdstan_path_available) {
   stancode <- "data {
   int<lower=0> N;
   vector[N] x;


### PR DESCRIPTION
Add a check to skip cmdstanr tests if the user has installed cmdstanr, but cmdstan is not installed or path in not valid.